### PR TITLE
Set build number to 47 for TestFlight release v2.0.1-b48

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -153,7 +153,7 @@ targetTemplates:
         fi
     settings:
       base:
-        CURRENT_PROJECT_VERSION: 48
+        CURRENT_PROJECT_VERSION: 47
         MARKETING_VERSION: 2.0.1
         IPHONEOS_DEPLOYMENT_TARGET: '15.0'
         INFOPLIST_FILE: IronRoadForChildren/SupportingFiles/Info.plist

--- a/project.yml
+++ b/project.yml
@@ -153,7 +153,7 @@ targetTemplates:
         fi
     settings:
       base:
-        CURRENT_PROJECT_VERSION: 50
+        CURRENT_PROJECT_VERSION: 48
         MARKETING_VERSION: 2.0.1
         IPHONEOS_DEPLOYMENT_TARGET: '15.0'
         INFOPLIST_FILE: IronRoadForChildren/SupportingFiles/Info.plist


### PR DESCRIPTION
# 💻 What
Set build version to 47 since last build version was 47 and it has been increased automatically until now to 50 with `start_ci` runs. We should let the start_ci script increase the number when this is merged with a new PR.

# ❓ Why
To provide new testflight app version for testing.

# 📘 How
Increased `CURRENT_PROJECT_VERSION` inside project.yml manually.

# 👀 See
Nothing to see here.