### PR TITLE
Increase build number to 48 for TestFlight release v2.0.1-b48

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -153,7 +153,7 @@ targetTemplates:
         fi
     settings:
       base:
-        CURRENT_PROJECT_VERSION: 47
+        CURRENT_PROJECT_VERSION: 48
         MARKETING_VERSION: 2.0.1
         IPHONEOS_DEPLOYMENT_TARGET: '15.0'
         INFOPLIST_FILE: IronRoadForChildren/SupportingFiles/Info.plist


### PR DESCRIPTION
# 💻 What
Increase build version to 48 since last build version was 47 and it has been increased automatically with `start_ci` runs. 

# ❓ Why
To provide new testflight app version for testing.

# 📘 How
Ran `bundle exec fastlane start_ci` which increased version number and created this commit automatically.

# 👀 See
Nothing to see here.