### PR TITLE
Bump version to 2.0.2 b:50

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -153,8 +153,8 @@ targetTemplates:
         fi
     settings:
       base:
-        CURRENT_PROJECT_VERSION: 48
-        MARKETING_VERSION: 2.0.1
+        CURRENT_PROJECT_VERSION: 50
+        MARKETING_VERSION: 2.0.2
         IPHONEOS_DEPLOYMENT_TARGET: '15.0'
         INFOPLIST_FILE: IronRoadForChildren/SupportingFiles/Info.plist
         ENABLE_PREVIEWS: true


### PR DESCRIPTION
# 💻 What
Increase Marketing version 2.0.2 and build version to 50.

# ❓ Why
To deploy new TestFlight version.

# 📘 How
Manueally inside `project.yml`

# 👀 See
---