### PR TITLE
Change giveaway to IRFC Tipp

### DIFF
--- a/IronRoadForChildren/Features/More/MoreView.swift
+++ b/IronRoadForChildren/Features/More/MoreView.swift
@@ -62,12 +62,12 @@ struct MoreView: View {
 					Spacer()
 
 					Button(action: {
-						openURL(URL(string: "https://irfc.at/app/app-gewinnspiel/")!)
+						openURL(URL(string: "https://www.oebb.at/de/regionale-angebote/steiermark/freizeit-ticket-steiermark")!)
 					}) {
 						HStack {
-							Image(systemName: "cube")
+							Image(systemName: "lightbulb")
 								.imageScale(.medium)
-							Text("Zum Gewinnspiel")
+							Text("IRFC Tipp")
 						}
 					}
 					.buttonStyle(IrfcWhiteRoundedButton())


### PR DESCRIPTION
# 💻 What
Changed giveaway button to "IRFC Tipp" that leads to ÖBB Site.

# ❓ Why
This year there is no giveaway and the customer had the idea to change it to "IRFC Tipp"

# 📘 How
Changed text and icon of the button

# 👀 See
Screenshots
<img width="335" alt="image" src="https://github.com/user-attachments/assets/6af96f3d-8d76-415d-a921-7d853c96dfaa" />
